### PR TITLE
bugfix: Markdown WELLMS-139

### DIFF
--- a/src/components/molecules/MarkdownRenderer/MarkdownRenderer.md
+++ b/src/components/molecules/MarkdownRenderer/MarkdownRenderer.md
@@ -42,6 +42,9 @@ const markdown = {
 
 # Header 1
 
+Alternative Header 1
+================
+
 ## Header 2
 
 ### Header 3

--- a/src/utils/components/markdown/index.ts
+++ b/src/utils/components/markdown/index.ts
@@ -27,26 +27,21 @@ const fixInlineStylesSyntaxForMarkdown = (content = ""): string => {
         .join('style="');
 };
 
-const fixMarkTagForMarkdown = (content = ""): string => {
-  let result = "";
-  let isFirstEquals = true;
+const fixMarkTagForMarkdown = (input: string): string => {
+  const regex = /==([^=]+)==/g;
+  const matches = input.match(regex);
+  if (!matches) return input;
 
-  for (let i = 0; i < content.length; i++) {
-    if (content[i] === "=" && content[i + 1] === "=") {
-      result += isFirstEquals ? "<mark>" : "</mark>";
-      isFirstEquals = !isFirstEquals;
-      i++;
-    } else {
-      result += content[i];
-    }
-  }
+  let result = input;
 
-  if (!isFirstEquals) {
-    result += "</mark>";
+  for (const match of matches) {
+    const replacedText = `<mark>${match.replace(/==/g, "")}</mark>`;
+
+    result = result.replace(match, replacedText);
   }
 
   return result;
-}
+};
 
 //TODO: Fix lookbehind ?<= regular expression, because it not works on safari
 // const getRegexBetween = (

--- a/src/utils/components/markdown/index.ts
+++ b/src/utils/components/markdown/index.ts
@@ -28,7 +28,7 @@ const fixInlineStylesSyntaxForMarkdown = (content = ""): string => {
 };
 
 const fixMarkTagForMarkdown = (input: string): string => {
-  const regex = /==([^=]+)==/g;
+  const regex = /==([^=\r\n]+)==/g;
   const matches = input.match(regex);
   if (!matches) return input;
 


### PR DESCRIPTION
`============` h1 are now working properly
![image](https://github.com/EscolaLMS/Components/assets/42141039/d73653f2-b170-4d35-96a5-fd00be94b172)

Also made this algorithm do it's job (text marking).
![image](https://github.com/EscolaLMS/Components/assets/42141039/70f1703a-32bd-4fd4-a8a7-41e6fd82c4be)
